### PR TITLE
Add file->package momentum and auto-aclocal

### DIFF
--- a/it_depends/autotools.py
+++ b/it_depends/autotools.py
@@ -6,7 +6,7 @@ from os import chdir, getcwd
 from pathlib import Path
 import shutil
 import subprocess
-from typing import Optional
+from typing import Optional, List, Tuple
 from semantic_version.base import Always, BaseSpec
 import logging
 import tempfile
@@ -158,7 +158,7 @@ class AutotoolsClassifier(DependencyClassifier):
         finally:
             chdir(orig_dir)
 
-        file_to_package_cache = []
+        file_to_package_cache: List[Tuple[str]]  = []
         deps = []
         for macro in trace.split('\n'):
             logger.debug(f"Handling: {macro}")


### PR DESCRIPTION
If a package already provide a certain fle use that one instead of looking for a potentialy different one in the file to package ubuntu database.
Also require and run `aclocal` to prepare for running `autoconf`. Sometimes it is needed (ex bitcoin core)