### PR TITLE
Tweak Podman discovery

### DIFF
--- a/it_depends/audit.py
+++ b/it_depends/audit.py
@@ -15,16 +15,24 @@ class OSVVulnerability(Vulnerability):
 
     """Additional keys available from the OSV Vulnerability db."""
     EXTRA_KEYS = [
-        "published", "modified", "withdrawn", "related", "package",
-        "details", "affects", "affected", "references", "severity",
-        "database_specific", "ecosystem_specific"]
+        "published",
+        "modified",
+        "withdrawn",
+        "related",
+        "package",
+        "details",
+        "affects",
+        "affected",
+        "references",
+        "severity",
+        "database_specific",
+        "ecosystem_specific",
+    ]
 
     def __init__(self, osv_dict: Dict):
         # Get the first available information as summary (N/A if none)
-        summary = osv_dict.get("summary", "") or osv_dict.get("details", "")\
-            or "N/A"
-        super().__init__(
-            osv_dict["id"], osv_dict.get("aliases", []), summary)
+        summary = osv_dict.get("summary", "") or osv_dict.get("details", "") or "N/A"
+        super().__init__(osv_dict["id"], osv_dict.get("aliases", []), summary)
 
         # Inherit all other attributes
         for k in OSVVulnerability.EXTRA_KEYS:
@@ -37,27 +45,25 @@ class OSVVulnerability(Vulnerability):
 
 class VulnerabilityProvider(ABC):
     """Interface of a vulnerability provider."""
-    def query(self, pkg: Package) ->\
-            Iterable[Vulnerability]:
+
+    def query(self, pkg: Package) -> Iterable[Vulnerability]:
         """Queries the vulnerability provider for vulnerabilities in pkg"""
         raise NotImplementedError()
 
 
 class OSVProject(VulnerabilityProvider):
     """OSV project vulnerability provider"""
+
     QUERY_URL = "https://api.osv.dev/v1/query"
 
-    def query(self, pkg: Package) ->\
-            Iterable[OSVVulnerability]:
+    def query(self, pkg: Package) -> Iterable[OSVVulnerability]:
         """Queries the OSV project for vulnerabilities in Package pkg"""
         q = {"version": str(pkg.version), "package": {"name": pkg.name}}
         r = post(OSVProject.QUERY_URL, json=q).json()
         return map(OSVVulnerability.from_osv_dict, r.get("vulns", []))
 
 
-def vulnerabilities(repo: PackageRepository, nworkers=None) -> \
-        PackageRepository:
-
+def vulnerabilities(repo: PackageRepository, nworkers=None) -> PackageRepository:
     def _get_vulninfo(pkg: Package) -> Tuple[Package, FrozenSet[Vulnerability]]:
         """Enrich a Package with vulnerability information"""
         ret = OSVProject().query(pkg)
@@ -66,9 +72,9 @@ def vulnerabilities(repo: PackageRepository, nworkers=None) -> \
         # thread handle the updates.
         return (pkg, frozenset({vuln: vuln for vuln in ret}))
 
-    with ThreadPoolExecutor(max_workers=nworkers) as executor, \
-        tqdm(desc="Checking for vulnerabilities", leave=False,
-             unit=" packages") as t:
+    with ThreadPoolExecutor(max_workers=nworkers) as executor, tqdm(
+        desc="Checking for vulnerabilities", leave=False, unit=" packages"
+    ) as t:
         futures = {executor.submit(_get_vulninfo, pkg): pkg for pkg in repo}
         t.total = len(futures)
 
@@ -77,8 +83,9 @@ def vulnerabilities(repo: PackageRepository, nworkers=None) -> \
                 t.update(1)
                 pkg, vulns = future.result()
             except Exception as exc:
-                logger.error("Failed to retrieve vulnerability information. "
-                             "Exception: {}".format(exc))
+                logger.error(
+                    "Failed to retrieve vulnerability information. " "Exception: {}".format(exc)
+                )
             else:
                 pkg.update_vulnerabilities(vulns)
 

--- a/it_depends/autotools.py
+++ b/it_depends/autotools.py
@@ -11,15 +11,21 @@ from typing import List, Optional, Tuple
 from it_depends.ubuntu.apt import cached_file_to_package as file_to_package
 
 from .dependencies import (
-    Dependency, DependencyResolver, PackageCache, ResolverAvailability, SimpleSpec, SourcePackage, SourceRepository,
-    Version
+    Dependency,
+    DependencyResolver,
+    PackageCache,
+    ResolverAvailability,
+    SimpleSpec,
+    SourcePackage,
+    SourceRepository,
+    Version,
 )
 
 logger = logging.getLogger(__name__)
 
 
 class AutotoolsResolver(DependencyResolver):
-    """ This attempts to parse configure.ac in an autotool based repo.
+    """This attempts to parse configure.ac in an autotool based repo.
     It supports the following macros:
         AC_INIT, AC_CHECK_HEADER, AC_CHECK_LIB, PKG_CHECK_MODULES
 
@@ -27,13 +33,17 @@ class AutotoolsResolver(DependencyResolver):
         does not handle boost deps
         assumes ubuntu host
     """
+
     name = "autotools"
     description = "classifies the dependencies of native/autotools packages parsing configure.ac"
 
     def is_available(self) -> ResolverAvailability:
         if shutil.which("autoconf") is None:
-            return ResolverAvailability(False, "`autoconf` does not appear to be installed! "
-                                               "Make sure it is installed and in the PATH.")
+            return ResolverAvailability(
+                False,
+                "`autoconf` does not appear to be installed! "
+                "Make sure it is installed and in the PATH.",
+            )
         return ResolverAvailability(True)
 
     def can_resolve_from_source(self, repo: SourceRepository) -> bool:
@@ -47,11 +57,10 @@ class AutotoolsResolver(DependencyResolver):
         https://www.gnu.org/software/autoconf/manual/autoconf-2.67/html_node/Generic-Headers.html
         """
         logger.info(f"AC_CHECK_HEADER {header_file}")
-        package_name = file_to_package(f"{re.escape(header_file)}", file_to_package_cache=file_to_package_cache)
-        return Dependency(package=package_name,
-                          semantic_version=SimpleSpec("*"),
-                          source="ubuntu"
-                          )
+        package_name = file_to_package(
+            f"{re.escape(header_file)}", file_to_package_cache=file_to_package_cache
+        )
+        return Dependency(package=package_name, semantic_version=SimpleSpec("*"), source="ubuntu")
 
     @staticmethod
     def _ac_check_lib(function, file_to_package_cache=None):
@@ -62,7 +71,10 @@ class AutotoolsResolver(DependencyResolver):
         """
         lib_file, function_name = function.split(".")
         logger.info(f"AC_CHECK_LIB {lib_file}")
-        package_name = file_to_package(f"lib{re.escape(lib_file)}(.a|.so)", file_to_package_cache=file_to_package_cache)
+        package_name = file_to_package(
+            f"lib{re.escape(lib_file)}(.a|.so)",
+            file_to_package_cache=file_to_package_cache,
+        )
         return Dependency(package=package_name, semantic_version=SimpleSpec("*"), source="ubuntu")
 
     @staticmethod
@@ -78,19 +90,23 @@ class AutotoolsResolver(DependencyResolver):
         module_file = re.escape(module_name + ".pc")
         logger.info(f"PKG_CHECK_MODULES {module_file}, {version}")
         package_name = file_to_package(module_file, file_to_package_cache=file_to_package_cache)
-        return Dependency(package=package_name, semantic_version=SimpleSpec(version), source="ubuntu")
+        return Dependency(
+            package=package_name, semantic_version=SimpleSpec(version), source="ubuntu"
+        )
 
     @staticmethod
     @functools.lru_cache(maxsize=128)
     def _replace_variables(token: str, configure: str):
         """
-            Search all variable occurrences in token and then try to find
-            bindings for them in the configure script.
+        Search all variable occurrences in token and then try to find
+        bindings for them in the configure script.
         """
         if "$" not in token:
             return token
         variable_list = re.findall(r"\$([a-zA-Z_0-9]+)|\${([_a-zA-Z0-9]+)}", token)
-        variables = set(var for var in itertools.chain(*variable_list) if var)  # remove dups and empty
+        variables = set(
+            var for var in itertools.chain(*variable_list) if var
+        )  # remove dups and empty
         for var in variables:
             logger.info(f"Trying to find bindings for {var} in configure")
 
@@ -100,7 +116,7 @@ class AutotoolsResolver(DependencyResolver):
             # For example:
             #    for var in THIS THAT ;
             # TODO/CHALLENGE Merge this two \/
-            solutions = re.findall(f"{var}=\\s*\"([^\"]*)\"", configure)
+            solutions = re.findall(f'{var}=\\s*"([^"]*)"', configure)
             solutions += re.findall(f"{var}=\\s*'([^']*)'", configure)
             if len(solutions) > 1:
                 logger.warning(f"Found several solutions for {var}: {solutions}")
@@ -108,7 +124,12 @@ class AutotoolsResolver(DependencyResolver):
                 logger.warning(f"No solution found for binding {var}")
                 continue
             logger.info(f"Found a solution {solutions}")
-            sol = (solutions+[None, ])[0]
+            sol = (
+                solutions
+                + [
+                    None,
+                ]
+            )[0]
             if sol is not None:
                 token = token.replace(f"${var}", sol).replace(f"${{{var}}}", sol)
         if "$" in token:
@@ -116,7 +137,7 @@ class AutotoolsResolver(DependencyResolver):
         return token
 
     def resolve_from_source(
-            self, repo: SourceRepository, cache: Optional[PackageCache] = None
+        self, repo: SourceRepository, cache: Optional[PackageCache] = None
     ) -> Optional[SourcePackage]:
         if not self.can_resolve_from_source(repo):
             return None
@@ -125,19 +146,31 @@ class AutotoolsResolver(DependencyResolver):
             # builds a temporary copy of configure.ac containing aclocal env
             subprocess.check_output(("aclocal", f"--output={tmp.name}"), cwd=repo.path)
             with open(tmp.name, "ab") as tmp2:
-                with open(repo.path/"configure.ac", "rb") as conf:
+                with open(repo.path / "configure.ac", "rb") as conf:
                     tmp2.write(conf.read())
 
             trace = subprocess.check_output(
-                ("autoconf", "-t", 'AC_CHECK_HEADER:$n:$1',
-                             "-t", 'AC_CHECK_LIB:$n:$1.$2',
-                             "-t", 'PKG_CHECK_MODULES:$n:$2',
-                             "-t", 'PKG_CHECK_MODULES_STATIC:$n', tmp.name), cwd=repo.path).decode("utf8")
-            configure = subprocess.check_output(["autoconf", tmp.name], cwd=repo.path).decode("utf8")
+                (
+                    "autoconf",
+                    "-t",
+                    "AC_CHECK_HEADER:$n:$1",
+                    "-t",
+                    "AC_CHECK_LIB:$n:$1.$2",
+                    "-t",
+                    "PKG_CHECK_MODULES:$n:$2",
+                    "-t",
+                    "PKG_CHECK_MODULES_STATIC:$n",
+                    tmp.name,
+                ),
+                cwd=repo.path,
+            ).decode("utf8")
+            configure = subprocess.check_output(["autoconf", tmp.name], cwd=repo.path).decode(
+                "utf8"
+            )
 
         file_to_package_cache: List[Tuple[str]] = []
         deps = []
-        for macro in trace.split('\n'):
+        for macro in trace.split("\n"):
             logger.debug(f"Handling: {macro}")
             macro, *arguments = macro.split(":")
             try:
@@ -147,28 +180,42 @@ class AutotoolsResolver(DependencyResolver):
                 continue
             try:
                 if macro == "AC_CHECK_HEADER":
-                    deps.append(self._ac_check_header(header_file=arguments[0], file_to_package_cache=file_to_package_cache))
+                    deps.append(
+                        self._ac_check_header(
+                            header_file=arguments[0],
+                            file_to_package_cache=file_to_package_cache,
+                        )
+                    )
                 elif macro == "AC_CHECK_LIB":
-                    deps.append(self._ac_check_lib(function=arguments[0], file_to_package_cache=file_to_package_cache))
+                    deps.append(
+                        self._ac_check_lib(
+                            function=arguments[0],
+                            file_to_package_cache=file_to_package_cache,
+                        )
+                    )
                 elif macro == "PKG_CHECK_MODULES":
                     module_name, *version = arguments[0].split(" ")
-                    deps.append(self._pkg_check_modules(module_name=module_name,
-                                                        version="".join(version),
-                                                        file_to_package_cache=file_to_package_cache))
+                    deps.append(
+                        self._pkg_check_modules(
+                            module_name=module_name,
+                            version="".join(version),
+                            file_to_package_cache=file_to_package_cache,
+                        )
+                    )
                 else:
                     logger.error("Macro not supported %r", macro)
             except Exception as e:
                 logger.error(str(e))
                 continue
 
-        '''
+        """
         # Identity of this package.
         PACKAGE_NAME='Bitcoin Core'
         PACKAGE_TARNAME='bitcoin'
         PACKAGE_VERSION='21.99.0'
         PACKAGE_STRING='Bitcoin Core 21.99.0'
         PACKAGE_BUGREPORT='https://github.com/bitcoin/bitcoin/issues'
-        PACKAGE_URL='https://bitcoincore.org/'''
+        PACKAGE_URL='https://bitcoincore.org/"""
         try:
             package_name = self._replace_variables("$PACKAGE_NAME", configure)
         except ValueError as e:
@@ -180,11 +227,11 @@ class AutotoolsResolver(DependencyResolver):
         except ValueError as e:
             logger.error(str(e))
             package_version = "0.0.0"
-            
+
         return SourcePackage(
             name=package_name,
             version=Version.coerce(package_version),
             source=self.name,
             dependencies=deps,
-            source_repo=repo
+            source_repo=repo,
         )

--- a/it_depends/cargo.py
+++ b/it_depends/cargo.py
@@ -9,21 +9,30 @@ from typing import Iterator, Optional, Type, Union, Dict
 from semantic_version.base import Always, BaseSpec
 
 from .dependencies import (
-    Dependency, DependencyResolver, Package, PackageCache, ResolverAvailability, SimpleSpec, SourcePackage,
-    SourceRepository, Version, InMemoryPackageCache
+    Dependency,
+    DependencyResolver,
+    Package,
+    PackageCache,
+    ResolverAvailability,
+    SimpleSpec,
+    SourcePackage,
+    SourceRepository,
+    Version,
+    InMemoryPackageCache,
 )
 
 logger = logging.getLogger(__name__)
 
+
 @BaseSpec.register_syntax
 class CargoSpec(SimpleSpec):
-    SYNTAX = 'cargo'
+    SYNTAX = "cargo"
 
     class Parser(SimpleSpec.Parser):
         @classmethod
         def parse(cls, expression):
             # The only difference here is that cargo clauses can have whitespace, so we need to strip each block:
-            blocks = [b.strip() for b in expression.split(',')]
+            blocks = [b.strip() for b in expression.split(",")]
             clause = Always()
             for block in blocks:
                 if not cls.NAIVE_SPEC.match(block):
@@ -34,21 +43,28 @@ class CargoSpec(SimpleSpec):
 
     def __str__(self):
         # remove the whitespace to canonicalize the spec
-        return ",".join(b.strip() for b in self.expression.split(','))
+        return ",".join(b.strip() for b in self.expression.split(","))
 
     def __or__(self, other):
         return CargoSpec(f"{self.expression},{other.expression}")
 
-def get_dependencies(repo: SourceRepository, check_for_cargo: bool = True, cache:Optional[PackageCache]=None) -> Iterator[Package]:
-    if check_for_cargo and shutil.which("cargo") is None:
-        raise ValueError("`cargo` does not appear to be installed! Make sure it is installed and in the PATH.")
 
-    metadata = json.loads(subprocess.check_output(["cargo", "metadata", "--format-version", "1"], cwd=repo.path))
+def get_dependencies(
+    repo: SourceRepository,
+    check_for_cargo: bool = True,
+    cache: Optional[PackageCache] = None,
+) -> Iterator[Package]:
+    if check_for_cargo and shutil.which("cargo") is None:
+        raise ValueError(
+            "`cargo` does not appear to be installed! Make sure it is installed and in the PATH."
+        )
+
+    metadata = json.loads(
+        subprocess.check_output(["cargo", "metadata", "--format-version", "1"], cwd=repo.path)
+    )
 
     if "workspace_members" in metadata:
-        workspace_members = {
-            member[:member.find(" ")] for member in metadata["workspace_members"]
-        }
+        workspace_members = {member[: member.find(" ")] for member in metadata["workspace_members"]}
     else:
         workspace_members = set()
 
@@ -62,12 +78,12 @@ def get_dependencies(repo: SourceRepository, check_for_cargo: bool = True, cache
 
         dependencies: Dict[str, Dependency] = {}
         for dep in package["dependencies"]:
-            if dep['kind'] is not None:
+            if dep["kind"] is not None:
                 continue
             if dep["name"] in dependencies:
                 dependencies[dep["name"]].semantic_version = dependencies[
-                                                                 dep["name"]].semantic_version | CargoResolver.parse_spec(
-                    dep["req"])
+                    dep["name"]
+                ].semantic_version | CargoResolver.parse_spec(dep["req"])
             else:
                 dependencies[dep["name"]] = Dependency(
                     package=dep["name"],
@@ -81,7 +97,7 @@ def get_dependencies(repo: SourceRepository, check_for_cargo: bool = True, cache
             source="cargo",
             dependencies=dependencies.values(),
             vulnerabilities=(),
-            **kwargs
+            **kwargs,
         )
 
 
@@ -91,8 +107,11 @@ class CargoResolver(DependencyResolver):
 
     def is_available(self) -> ResolverAvailability:
         if shutil.which("cargo") is None:
-            return ResolverAvailability(False, "`cargo` does not appear to be installed! "
-                                               "Make sure it is installed and in the PATH.")
+            return ResolverAvailability(
+                False,
+                "`cargo` does not appear to be installed! "
+                "Make sure it is installed and in the PATH.",
+            )
         return ResolverAvailability(True)
 
     @classmethod
@@ -103,7 +122,7 @@ class CargoResolver(DependencyResolver):
         return bool(self.is_available()) and (repo.path / "Cargo.toml").exists()
 
     def resolve_from_source(
-            self, repo: SourceRepository, cache: Optional[PackageCache] = None
+        self, repo: SourceRepository, cache: Optional[PackageCache] = None
     ) -> Optional[SourcePackage]:
         if not self.can_resolve_from_source(repo):
             return None
@@ -139,13 +158,13 @@ class CargoResolver(DependencyResolver):
         with cache:
             for semantic_version in map(str.strip, semantic_versions):
                 if semantic_version[0].isnumeric():
-                    semantic_version="="+semantic_version
+                    semantic_version = "=" + semantic_version
                 pkgid = f'{pkgid.split("=")[0].strip()} = "{semantic_version}"'
 
                 logger.debug(f"Found {pkgid} for {dependency} in crates.io")
                 with tempfile.TemporaryDirectory() as tmpdir:
                     subprocess.check_output(["cargo", "init"], cwd=tmpdir)
-                    with open(Path(tmpdir)/"Cargo.toml", "a") as f:
+                    with open(Path(tmpdir) / "Cargo.toml", "a") as f:
                         f.write(f"{pkgid}\n")
                     self.resolve_from_source(SourceRepository(path=tmpdir), cache)
         cache.set_resolved(dependency)

--- a/it_depends/cli.py
+++ b/it_depends/cli.py
@@ -26,7 +26,9 @@ def no_stdout() -> Iterator[TextIO]:
         sys.stdout = saved_stdout
 
 
-def parse_path_or_package_name(path_or_name: str) -> Union[SourceRepository, Dependency]:
+def parse_path_or_package_name(
+    path_or_name: str,
+) -> Union[SourceRepository, Dependency]:
     repo_path = Path(path_or_name)
     try:
         dependency: Optional[Dependency] = Dependency.from_string(path_or_name)
@@ -46,45 +48,104 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
 
     parser = argparse.ArgumentParser(description="a source code dependency analyzer")
 
-    parser.add_argument("PATH_OR_NAME", nargs="?", type=str, default=".",
-                        help="path to the directory to analyze, or a package name in the form of "
-                             "RESOLVER_NAME:PACKAGE_NAME[@OPTIONAL_VERSION], where RESOLVER_NAME is a resolver listed "
-                             "in `it-depends --list`. For example: \"pip:numpy\", \"apt:libc6@2.31\", or "
-                             "\"npm:lodash@>=4.17.0\".")
+    parser.add_argument(
+        "PATH_OR_NAME",
+        nargs="?",
+        type=str,
+        default=".",
+        help="path to the directory to analyze, or a package name in the form of "
+        "RESOLVER_NAME:PACKAGE_NAME[@OPTIONAL_VERSION], where RESOLVER_NAME is a resolver listed "
+        'in `it-depends --list`. For example: "pip:numpy", "apt:libc6@2.31", or '
+        '"npm:lodash@>=4.17.0".',
+    )
 
-    parser.add_argument("--audit", "-a", action="store_true", help="audit packages for known vulnerabilities using "
-                                                                   "Google OSV")
+    parser.add_argument(
+        "--audit",
+        "-a",
+        action="store_true",
+        help="audit packages for known vulnerabilities using " "Google OSV",
+    )
     parser.add_argument("--list", "-l", action="store_true", help="list available package resolver")
-    parser.add_argument("--database", "-db", type=str, nargs="?", default=DEFAULT_DB_PATH,
-                        help="alternative path to load/store the database, or \":memory:\" to cache all results in "
-                             f"memory rather than reading/writing to disk (default is {DEFAULT_DB_PATH!s})")
-    parser.add_argument("--clear-cache", action="store_true", help="clears the database specified by `--database` "
-                                                                   "(equivalent to deleting the database file)")
-    parser.add_argument("--compare", "-c", nargs="?", type=str,
-                        help="compare PATH_OR_NAME to another package specified according to the same rules as "
-                             "PATH_OR_NAME; this option will override the --output-format option and will instead "
-                             "output a floating point similarity metric. By default, the metric will be in the range"
-                             "[0, ∞), with zero meaning that the dependency graphs are identical. For a metric in the "
-                             "range [0, 1], see the `--normalize` option.")
-    parser.add_argument("--normalize", "-n", action="store_true",
-                        help="Used in conjunction with `--compare`, this will change the output metric to be in the "
-                             "range [0, 1] where 1 means the graphs are identical and 0 means the graphs are as "
-                             "different as possible.")
-    parser.add_argument("--output-format", "-f", choices=("json", "dot", "html"), default="json",
-                        help="how the output should be formatted (default is JSON)")
-    parser.add_argument("--output-file", "-o", type=str, default=None, help="path to the output file; default is to "
-                                                                            "write output to STDOUT")
-    parser.add_argument("--force", action="store_true", help="force overwriting the output file even if it already "
-                                                             "exists")
-    parser.add_argument("--all-versions", action="store_true",
-                        help="for `--output-format html`, this option will emit all package versions that satisfy each "
-                             "dependency")
-    parser.add_argument("--depth-limit", "-d", type=int, default=-1,
-                        help="depth limit for recursively solving dependencies (default is -1 to resolve all "
-                             "dependencies)")
-    parser.add_argument("--max-workers", "-j", type=int, default=None, help="maximum number of jobs to run concurrently"
-                                                                            " (default is # of CPUs)")
-    parser.add_argument("--version", "-v", action="store_true", help="print it-depends' version and exit")
+    parser.add_argument(
+        "--database",
+        "-db",
+        type=str,
+        nargs="?",
+        default=DEFAULT_DB_PATH,
+        help='alternative path to load/store the database, or ":memory:" to cache all results in '
+        f"memory rather than reading/writing to disk (default is {DEFAULT_DB_PATH!s})",
+    )
+    parser.add_argument(
+        "--clear-cache",
+        action="store_true",
+        help="clears the database specified by `--database` "
+        "(equivalent to deleting the database file)",
+    )
+    parser.add_argument(
+        "--compare",
+        "-c",
+        nargs="?",
+        type=str,
+        help="compare PATH_OR_NAME to another package specified according to the same rules as "
+        "PATH_OR_NAME; this option will override the --output-format option and will instead "
+        "output a floating point similarity metric. By default, the metric will be in the range"
+        "[0, ∞), with zero meaning that the dependency graphs are identical. For a metric in the "
+        "range [0, 1], see the `--normalize` option.",
+    )
+    parser.add_argument(
+        "--normalize",
+        "-n",
+        action="store_true",
+        help="Used in conjunction with `--compare`, this will change the output metric to be in the "
+        "range [0, 1] where 1 means the graphs are identical and 0 means the graphs are as "
+        "different as possible.",
+    )
+    parser.add_argument(
+        "--output-format",
+        "-f",
+        choices=("json", "dot", "html"),
+        default="json",
+        help="how the output should be formatted (default is JSON)",
+    )
+    parser.add_argument(
+        "--output-file",
+        "-o",
+        type=str,
+        default=None,
+        help="path to the output file; default is to " "write output to STDOUT",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="force overwriting the output file even if it already " "exists",
+    )
+    parser.add_argument(
+        "--all-versions",
+        action="store_true",
+        help="for `--output-format html`, this option will emit all package versions that satisfy each "
+        "dependency",
+    )
+    parser.add_argument(
+        "--depth-limit",
+        "-d",
+        type=int,
+        default=-1,
+        help="depth limit for recursively solving dependencies (default is -1 to resolve all "
+        "dependencies)",
+    )
+    parser.add_argument(
+        "--max-workers",
+        "-j",
+        type=int,
+        default=None,
+        help="maximum number of jobs to run concurrently" " (default is # of CPUs)",
+    )
+    parser.add_argument(
+        "--version",
+        "-v",
+        action="store_true",
+        help="print it-depends' version and exit",
+    )
 
     args = parser.parse_args(argv[1:])
 
@@ -101,7 +162,9 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         repo = parse_path_or_package_name(args.PATH_OR_NAME)
 
         if args.compare is not None:
-            to_compare: Optional[Union[SourceRepository, Dependency]] = parse_path_or_package_name(args.compare)
+            to_compare: Optional[Union[SourceRepository, Dependency]] = parse_path_or_package_name(
+                args.compare
+            )
         else:
             to_compare = None
     except ValueError as e:
@@ -116,8 +179,10 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
                 while True:
                     if args.database != DEFAULT_DB_PATH:
                         sys.stderr.write(f"Cache file: {db_path.absolute()}\n")
-                    sys.stderr.write("Deleting the cache will require all past resoltuions to be recalculated, which "
-                                     "can be slow.\nAre you sure? [yN] ")
+                    sys.stderr.write(
+                        "Deleting the cache will require all past resoltuions to be recalculated, which "
+                        "can be slow.\nAre you sure? [yN] "
+                    )
                     try:
                         choice = input("").lower().strip()
                     except KeyboardInterrupt:
@@ -141,14 +206,15 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         sys.stderr.write(f"Available resolvers for {path}:\n")
         sys.stderr.flush()
         for name, classifier in sorted((c.name, c) for c in resolvers()):
-            sys.stdout.write(name + " "*(12-len(name)))
+            sys.stdout.write(name + " " * (12 - len(name)))
             sys.stdout.flush()
             available = classifier.is_available()
             if not available:
                 sys.stderr.write(f"\tnot available: {available.reason}")
                 sys.stderr.flush()
-            elif isinstance(repo, SourceRepository) and \
-                    not classifier.can_resolve_from_source(repo):
+            elif isinstance(repo, SourceRepository) and not classifier.can_resolve_from_source(
+                repo
+            ):
                 sys.stderr.write("\tincompatible with this path")
                 sys.stderr.flush()
             elif isinstance(repo, Dependency) and repo.source != classifier.name:
@@ -167,21 +233,28 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             if args.output_file is None or args.output_file == "-":
                 output_file = real_stdout
             elif not args.force and Path(args.output_file).exists():
-                sys.stderr.write(f"{args.output_file} already exists!\nRe-run with `--force` to overwrite the file.\n")
+                sys.stderr.write(
+                    f"{args.output_file} already exists!\nRe-run with `--force` to overwrite the file.\n"
+                )
                 return 1
             else:
                 output_file = open(args.output_file, "w")
             with DBPackageCache(args.database) as cache:
                 try:
                     package_list = resolve(
-                        repo, cache=cache, depth_limit=args.depth_limit, max_workers=args.max_workers
+                        repo,
+                        cache=cache,
+                        depth_limit=args.depth_limit,
+                        max_workers=args.max_workers,
                     )
                 except ValueError as e:
                     if not args.clear_cache or args.PATH_OR_NAME.strip():
                         sys.stderr.write(f"{e!s}\n")
                     return 1
                 if not package_list:
-                    sys.stderr.write(f"Try --list to check for available resolvers for {args.PATH_OR_NAME}\n")
+                    sys.stderr.write(
+                        f"Try --list to check for available resolvers for {args.PATH_OR_NAME}\n"
+                    )
                     sys.stderr.flush()
 
                 # TODO: Should the cache be updated instead????
@@ -189,16 +262,26 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
                     package_list = vulnerabilities(package_list)
 
                 if to_compare is not None:
-                    to_compare_list = \
-                        resolve(to_compare, cache=cache, depth_limit=args.depth_limit, max_workers=args.max_workers)
-                    output_file.write(str(package_list.to_graph().distance_to(
-                        to_compare_list.to_graph(), normalize=args.normalize
-                    )))
+                    to_compare_list = resolve(
+                        to_compare,
+                        cache=cache,
+                        depth_limit=args.depth_limit,
+                        max_workers=args.max_workers,
+                    )
+                    output_file.write(
+                        str(
+                            package_list.to_graph().distance_to(
+                                to_compare_list.to_graph(), normalize=args.normalize
+                            )
+                        )
+                    )
                     output_file.write("\n")
                 elif args.output_format == "dot":
                     output_file.write(cache.to_dot(package_list.source_packages).source)
                 elif args.output_format == "html":
-                    output_file.write(graph_to_html(package_list, collapse_versions=not args.all_versions))
+                    output_file.write(
+                        graph_to_html(package_list, collapse_versions=not args.all_versions)
+                    )
                     if output_file is not real_stdout:
                         output_file.flush()
                         webbrowser.open(output_file.name)
@@ -207,10 +290,12 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
                 else:
                     raise NotImplementedError(f"TODO: Implement output format {args.output_format}")
     except OperationalError as e:
-        sys.stderr.write(f"Database error: {e!r}\n\nThis can occur if your database was created with an older version "
-                         f"of it-depends and was unable to be updated. If you remove {args.database} or run "
-                         "`it-depends --clear-cache` and try again, the database will automatically be rebuilt from "
-                         "scratch.")
+        sys.stderr.write(
+            f"Database error: {e!r}\n\nThis can occur if your database was created with an older version "
+            f"of it-depends and was unable to be updated. If you remove {args.database} or run "
+            "`it-depends --clear-cache` and try again, the database will automatically be rebuilt from "
+            "scratch."
+        )
         return 1
     finally:
         if output_file is not None and output_file != sys.stdout:

--- a/it_depends/db.py
+++ b/it_depends/db.py
@@ -2,12 +2,27 @@ from pathlib import Path
 from typing import Any, Dict, FrozenSet, Iterable, Iterator, Optional, Tuple, Union
 
 from semantic_version import Version
-from sqlalchemy import Column, create_engine, distinct, ForeignKey, Integer, String, UniqueConstraint
+from sqlalchemy import (
+    Column,
+    create_engine,
+    distinct,
+    ForeignKey,
+    Integer,
+    String,
+    UniqueConstraint,
+)
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import relationship, sessionmaker
 
-from .dependencies import resolver_by_name, Dependency, DependencyResolver, Package, SemanticVersion, PackageCache
+from .dependencies import (
+    resolver_by_name,
+    Dependency,
+    DependencyResolver,
+    Package,
+    SemanticVersion,
+    PackageCache,
+)
 from .it_depends import APP_DIRS
 
 DEFAULT_DB_PATH = Path(APP_DIRS.user_cache_dir) / "dependencies.sqlite"
@@ -27,6 +42,7 @@ class Resolution(Base):  # type: ignore
         UniqueConstraint("package", "version", "source", name="resolution_unique_constraint"),
     )
 
+
 class Updated(Base):  # type: ignore
     __tablename__ = "updated"
 
@@ -37,7 +53,9 @@ class Updated(Base):  # type: ignore
     resolver = Column(String, nullable=True)
 
     __table_args__ = (
-        UniqueConstraint("package", "version", "source", "resolver", name="updated_unique_constraint"),
+        UniqueConstraint(
+            "package", "version", "source", "resolver", name="updated_unique_constraint"
+        ),
     )
 
 
@@ -52,7 +70,12 @@ class DBDependency(Base, Dependency):  # type: ignore
     semantic_version_string = Column("semantic_version", String, nullable=True)
 
     __table_args__ = (
-        UniqueConstraint("from_package_id", "package", "semantic_version", name="dependency_unique_constraint"),
+        UniqueConstraint(
+            "from_package_id",
+            "package",
+            "semantic_version",
+            name="dependency_unique_constraint",
+        ),
     )
 
     def __init__(self, package: "DBPackage", dep: Dependency):
@@ -76,7 +99,12 @@ class DependencyMapping:
     def __init__(self, package: "DBPackage"):
         super().__init__()
         self._deps: Dict[str, Dependency] = {
-            dep.package: Dependency(package=dep.package, source=dep.source, semantic_version=dep.semantic_version) for dep in package.raw_dependencies
+            dep.package: Dependency(
+                package=dep.package,
+                source=dep.source,
+                semantic_version=dep.semantic_version,
+            )
+            for dep in package.raw_dependencies
         }
 
     def items(self) -> Iterator[Tuple[str, Dependency]]:
@@ -116,7 +144,11 @@ class DBPackage(Base, Package):  # type: ignore
         UniqueConstraint("name", "version", "source", name="package_unique_constraint"),
     )
 
-    raw_dependencies = relationship("DBDependency", back_populates="from_package", cascade="all, delete, delete-orphan")
+    raw_dependencies = relationship(
+        "DBDependency",
+        back_populates="from_package",
+        cascade="all, delete, delete-orphan",
+    )
 
     def __init__(self, package: Package):
         # We intentionally skip calling super().__init__()
@@ -141,10 +173,19 @@ class DBPackage(Base, Package):  # type: ignore
         return package
 
     def to_package(self) -> Package:
-        return Package(source=self.source, name=self.name, version=self.version, dependencies=(
-            Dependency(package=dep.package, semantic_version=dep.semantic_version, source=dep.source)
-            for dep in self.raw_dependencies
-        ))
+        return Package(
+            source=self.source,
+            name=self.name,
+            version=self.version,
+            dependencies=(
+                Dependency(
+                    package=dep.package,
+                    semantic_version=dep.semantic_version,
+                    source=dep.source,
+                )
+                for dep in self.raw_dependencies
+            ),
+        )
 
     @property
     def version(self) -> Version:
@@ -166,11 +207,19 @@ class SourceFilteredPackageCache(PackageCache):
         self.parent: DBPackageCache = parent
 
     def __len__(self):
-        return self.parent.session.query(DBPackage).filter(DBPackage.source_name.like(self.source)).count()
+        return (
+            self.parent.session.query(DBPackage)
+            .filter(DBPackage.source_name.like(self.source))
+            .count()
+        )
 
     def __iter__(self) -> Iterator[Package]:
-        yield from [p.to_package()
-                    for p in self.parent.session.query(DBPackage).filter(DBPackage.source_name.like(self.source)).all()]
+        yield from [
+            p.to_package()
+            for p in self.parent.session.query(DBPackage)
+            .filter(DBPackage.source_name.like(self.source))
+            .all()
+        ]
 
     def was_resolved(self, dependency: Dependency) -> bool:
         return self.parent.was_resolved(dependency)
@@ -182,13 +231,22 @@ class SourceFilteredPackageCache(PackageCache):
         return SourceFilteredPackageCache(source, self.parent)
 
     def package_versions(self, package_name: str) -> Iterator[Package]:
-        yield from [p.to_package() for p in self.parent.session.query(DBPackage).filter(
-            DBPackage.name.like(package_name), DBPackage.source_name.like(self.source)
-        ).all()]
+        yield from [
+            p.to_package()
+            for p in self.parent.session.query(DBPackage)
+            .filter(
+                DBPackage.name.like(package_name),
+                DBPackage.source_name.like(self.source),
+            )
+            .all()
+        ]
 
     def package_full_names(self) -> FrozenSet[str]:
-        return frozenset(self.parent.session.query(distinct(DBPackage.name))
-                         .filter(DBPackage.source_name.like(self.source)).all())
+        return frozenset(
+            self.parent.session.query(distinct(DBPackage.name))
+            .filter(DBPackage.source_name.like(self.source))
+            .all()
+        )
 
     def match(self, to_match: Union[str, Package, Dependency]) -> Iterator[Package]:
         return self.parent.match(to_match)
@@ -215,7 +273,7 @@ class DBPackageCache(PackageCache):
             pass
         elif isinstance(db, str):
             if db.startswith("sqlite:///"):
-                db = db[len("sqlite:///"):]
+                db = db[len("sqlite:///") :]
             db = Path(db)
         if isinstance(db, Path):
             db.parent.mkdir(parents=True, exist_ok=True)
@@ -245,8 +303,10 @@ class DBPackageCache(PackageCache):
         for package in packages:
             for existing in self.match(package):
                 if len(existing.dependencies) > len(package.dependencies):
-                    raise ValueError(f"Package {package!s} has already been resolved with more dependencies: "
-                                     f"{existing!s}")
+                    raise ValueError(
+                        f"Package {package!s} has already been resolved with more dependencies: "
+                        f"{existing!s}"
+                    )
                 elif existing.dependencies != package.dependencies:
                     existing.dependencies = package.dependencies
                     self.session.commit()
@@ -273,12 +333,19 @@ class DBPackageCache(PackageCache):
 
     def package_versions(self, package_full_name: str) -> Iterator[Package]:
         yield from [
-            p.to_package() for p in self.session.query(DBPackage).filter(DBPackage.name.like(package_full_name)).all()
+            p.to_package()
+            for p in self.session.query(DBPackage)
+            .filter(DBPackage.name.like(package_full_name))
+            .all()
         ]
 
     def package_full_names(self) -> FrozenSet[str]:
-        return frozenset(f"{result[0]}:{result[1]}" for result in self.session.query(distinct(DBPackage.source),
-                                                                                     distinct(DBPackage.name)).all())
+        return frozenset(
+            f"{result[0]}:{result[1]}"
+            for result in self.session.query(
+                distinct(DBPackage.source), distinct(DBPackage.name)
+            ).all()
+        )
 
     def _make_query(self, to_match: Union[str, Package], source: Optional[str] = None):
         if source is None and isinstance(to_match, Package):
@@ -289,7 +356,9 @@ class DBPackageCache(PackageCache):
             filters = ()
         if isinstance(to_match, Package):
             return self.session.query(DBPackage).filter(
-                DBPackage.name.like(to_match.name), DBPackage.version_str.like(str(to_match.version)), *filters
+                DBPackage.name.like(to_match.name),
+                DBPackage.version_str.like(str(to_match.version)),
+                *filters,
             )
         else:
             return self.session.query(DBPackage).filter(DBPackage.name.like(to_match), *filters)
@@ -305,43 +374,70 @@ class DBPackageCache(PackageCache):
             else:
                 source = None
             # we intentionally build a list before yielding so that we don't keep the session query lingering
-            yield from [package.to_package() for package in self._make_query(to_match, source=source).all()]
+            yield from [
+                package.to_package() for package in self._make_query(to_match, source=source).all()
+            ]
 
     def was_resolved(self, dependency: Dependency) -> bool:
-        return self.session.query(Resolution).filter(
-            Resolution.package.like(dependency.package),
-            Resolution.version == str(dependency.semantic_version),
-            Resolution.source.like(dependency.source),
-        ).limit(1).count() > 0
+        return (
+            self.session.query(Resolution)
+            .filter(
+                Resolution.package.like(dependency.package),
+                Resolution.version == str(dependency.semantic_version),
+                Resolution.source.like(dependency.source),
+            )
+            .limit(1)
+            .count()
+            > 0
+        )
 
     def set_resolved(self, dependency: Dependency):
         if self.was_resolved(dependency):
             return
         self.session.add(
-            Resolution(package=dependency.package, version=str(dependency.semantic_version), source=dependency.source)
+            Resolution(
+                package=dependency.package,
+                version=str(dependency.semantic_version),
+                source=dependency.source,
+            )
         )
         self.session.commit()
 
-    def updated_by(self, package:Package) -> FrozenSet[str]:
-        return frozenset(u.resolver for u in self.session.query(Updated).filter(
-            Updated.source.like(package.source),
-            Updated.package.like(package.name),
-            Updated.version == str(package.version)))
+    def updated_by(self, package: Package) -> FrozenSet[str]:
+        return frozenset(
+            u.resolver
+            for u in self.session.query(Updated).filter(
+                Updated.source.like(package.source),
+                Updated.package.like(package.name),
+                Updated.version == str(package.version),
+            )
+        )
 
     def was_updated(self, package: Package, resolver: str) -> bool:
         if package.source == resolver:
             return True
-        return self.session.query(Updated).filter(
-            Updated.source.like(package.source),
-            Updated.package.like(package.name),
-            Updated.version.like(str(package.version)),
-            Updated.resolver.like(resolver)
-        ).limit(1).count() > 0
+        return (
+            self.session.query(Updated)
+            .filter(
+                Updated.source.like(package.source),
+                Updated.package.like(package.name),
+                Updated.version.like(str(package.version)),
+                Updated.resolver.like(resolver),
+            )
+            .limit(1)
+            .count()
+            > 0
+        )
 
     def set_updated(self, package: Package, resolver: str):
         if self.was_updated(package, resolver):
             return
         self.session.add(
-            Updated(package=package.name, version=str(package.version), source=package.source, resolver=resolver)
+            Updated(
+                package=package.name,
+                version=str(package.version),
+                source=package.source,
+                resolver=resolver,
+            )
         )
         self.session.commit()

--- a/it_depends/docker.py
+++ b/it_depends/docker.py
@@ -289,8 +289,7 @@ class DockerContainer:
             sock = _discover_podman_socket()
             cli = docker.APIClient(base_url=sock)
         except DockerException as e:
-            # TODO: Disambiguate error in the podman case.
-            raise ValueError("Docker not installed. Try `sudo apt install docker`.") from e
+            raise ValueError(f"Could not connect to socket: {e}") from e
         with tqdm(desc="Archiving the build directory", unit=" steps", leave=False) as t:
             last_line = 0
             last_step = None

--- a/it_depends/docker.py
+++ b/it_depends/docker.py
@@ -289,7 +289,7 @@ class DockerContainer:
             sock = _discover_podman_socket()
             cli = docker.APIClient(base_url=sock)
         except DockerException as e:
-            raise ValueError(f"Could not connect to socket: {e}") from e
+            raise ValueError(f"Could not connect to socket: sock={sock} {e}") from e
         with tqdm(desc="Archiving the build directory", unit=" steps", leave=False) as t:
             last_line = 0
             last_step = None

--- a/it_depends/go.py
+++ b/it_depends/go.py
@@ -15,16 +15,24 @@ from semantic_version import Version
 from semantic_version.base import BaseSpec, Range, SimpleSpec
 
 from .dependencies import (
-    Dependency, DependencyResolver, SourcePackage, SourceRepository, Package, PackageCache, SemanticVersion
+    Dependency,
+    DependencyResolver,
+    SourcePackage,
+    SourceRepository,
+    Package,
+    PackageCache,
+    SemanticVersion,
 )
 from . import vcs
 
 log = getLogger(__file__)
 
-GITHUB_URL_MATCH = re.compile(r"\s*https?://(www\.)?github.com/([^/]+)/(.+?)(\.git)?\s*", re.IGNORECASE)
+GITHUB_URL_MATCH = re.compile(
+    r"\s*https?://(www\.)?github.com/([^/]+)/(.+?)(\.git)?\s*", re.IGNORECASE
+)
 REQUIRE_LINE_REGEX = r"\s*([^\s]+)\s+([^\s]+)\s*(//\s*indirect\s*)?"
 REQUIRE_LINE_MATCH = re.compile(REQUIRE_LINE_REGEX)
-REQUIRE_MATCH = re.compile(fr"\s*require\s+{REQUIRE_LINE_REGEX}")
+REQUIRE_MATCH = re.compile(rf"\s*require\s+{REQUIRE_LINE_REGEX}")
 REQUIRE_BLOCK_MATCH = re.compile(r"\s*require\s+\(\s*")
 MODULE_MATCH = re.compile(r"\s*module\s+([^\s]+)\s*")
 
@@ -56,11 +64,7 @@ class MetadataParser(HTMLParser):
 
 def git_commit(path: Optional[str] = None) -> Optional[str]:
     try:
-        return check_output(
-            ["git", "rev-parse", "HEAD"],
-            cwd=path,
-            stderr=DEVNULL
-        ).decode("utf-8")
+        return check_output(["git", "rev-parse", "HEAD"], cwd=path, stderr=DEVNULL).decode("utf-8")
     except CalledProcessError:
         return None
 
@@ -84,7 +88,7 @@ class GoVersion:
 
 @BaseSpec.register_syntax
 class GoSpec(SimpleSpec):
-    SYNTAX = 'go'
+    SYNTAX = "go"
 
     class Parser(SimpleSpec.Parser):
         @classmethod
@@ -152,21 +156,25 @@ class GoModule:
                     import_path=f"github.com/{github_org}/{github_repo}",
                     git_url=f"https://github.com/{github_org}/{github_repo}",
                     tag=tag,
-                    check_for_github=False
+                    check_for_github=False,
                 )
             raise
 
     @staticmethod
-    def from_git(import_path: str, git_url: str, tag: str, check_for_github: bool = True, force_clone: bool = False):
+    def from_git(
+        import_path: str,
+        git_url: str,
+        tag: str,
+        check_for_github: bool = True,
+        force_clone: bool = False,
+    ):
         if check_for_github:
             m = GITHUB_URL_MATCH.fullmatch(git_url)
             if m:
                 return GoModule.from_github(m.group(2), m.group(3), tag)
         log.info(f"Attempting to clone {git_url}")
         with TemporaryDirectory() as tempdir:
-            env = {
-                "GIT_TERMINAL_PROMPT": "0"
-            }
+            env = {"GIT_TERMINAL_PROMPT": "0"}
             if os.environ.get("GIT_SSH", "") == "" and os.environ.get("GIT_SSH_COMMAND", "") == "":
                 # disable any ssh connection pooling by git
                 env["GIT_SSH_COMMAND"] = "ssh -o ControlMaster=no"
@@ -174,30 +182,65 @@ class GoModule:
                 # this will happen if we are resolving a wildcard, typically if the user called something like
                 # `it-depends go:github.com/ethereum/go-ethereum`
                 td = Path(tempdir)
-                check_call(["git", "clone", "--depth", "1", git_url, td.name],
-                           cwd=td.parent, stderr=DEVNULL, stdout=DEVNULL, env=env)
+                check_call(
+                    ["git", "clone", "--depth", "1", git_url, td.name],
+                    cwd=td.parent,
+                    stderr=DEVNULL,
+                    stdout=DEVNULL,
+                    env=env,
+                )
             else:
                 check_call(["git", "init"], cwd=tempdir, stderr=DEVNULL, stdout=DEVNULL)
-                check_call(["git", "remote", "add", "origin", git_url], cwd=tempdir, stderr=DEVNULL, stdout=DEVNULL)
+                check_call(
+                    ["git", "remote", "add", "origin", git_url],
+                    cwd=tempdir,
+                    stderr=DEVNULL,
+                    stdout=DEVNULL,
+                )
                 git_hash = GoModule.tag_to_git_hash(tag)
                 try:
-                    check_call(["git", "fetch", "--depth", "1", "origin", git_hash], cwd=tempdir, stderr=DEVNULL,
-                               stdout=DEVNULL, env=env)
+                    check_call(
+                        ["git", "fetch", "--depth", "1", "origin", git_hash],
+                        cwd=tempdir,
+                        stderr=DEVNULL,
+                        stdout=DEVNULL,
+                        env=env,
+                    )
                 except CalledProcessError:
                     # not all git servers support `git fetch --depth 1` on a hash
                     try:
-                        check_call(["git", "fetch", "origin"], cwd=tempdir, stderr=DEVNULL, stdout=DEVNULL, env=env)
+                        check_call(
+                            ["git", "fetch", "origin"],
+                            cwd=tempdir,
+                            stderr=DEVNULL,
+                            stdout=DEVNULL,
+                            env=env,
+                        )
                     except CalledProcessError:
                         log.error(f"Could not clone {git_url} for {import_path!r}")
                         return GoModule(import_path)
                     try:
-                        check_call(["git", "checkout", git_hash], cwd=tempdir, stderr=DEVNULL, stdout=DEVNULL, env=env)
+                        check_call(
+                            ["git", "checkout", git_hash],
+                            cwd=tempdir,
+                            stderr=DEVNULL,
+                            stdout=DEVNULL,
+                            env=env,
+                        )
                     except CalledProcessError:
                         if tag.startswith("="):
                             return GoModule.from_git(import_path, git_url, tag[1:])
-                        log.warning(f"Could not checkout tag {tag} of {git_url} for {import_path!r}; "
-                                    "reverting to the main branch")
-                        return GoModule.from_git(import_path, git_url, tag, check_for_github=False, force_clone=True)
+                        log.warning(
+                            f"Could not checkout tag {tag} of {git_url} for {import_path!r}; "
+                            "reverting to the main branch"
+                        )
+                        return GoModule.from_git(
+                            import_path,
+                            git_url,
+                            tag,
+                            check_for_github=False,
+                            force_clone=True,
+                        )
             go_mod_path = Path(tempdir) / "go.mod"
             if not go_mod_path.exists():
                 # the package likely doesn't have any dependencies
@@ -262,7 +305,9 @@ class GoModule:
             new_url, imports = GoModule.meta_imports_for_prefix(meta_import.prefix)
             meta_import2 = GoModule.match_go_import(imports, import_path)
             if meta_import != meta_import2:
-                raise ValueError(f"{url} and {new_url} disagree about go-import for {meta_import.prefix!r}")
+                raise ValueError(
+                    f"{url} and {new_url} disagree about go-import for {meta_import.prefix!r}"
+                )
         # validateRepoRoot(meta_import.RepoRoot)
         if meta_import.vcs == "mod":
             the_vcs = vcs.VCS_MOD
@@ -271,7 +316,12 @@ class GoModule:
             if the_vcs is None:
                 raise ValueError(f"{url}: unknown VCS {meta_import.vcs!r}")
         vcs.check_go_vcs(the_vcs, meta_import.prefix)
-        return vcs.Repository(repo=meta_import.repo_root, root=meta_import.prefix, is_custom=True, vcs=the_vcs)
+        return vcs.Repository(
+            repo=meta_import.repo_root,
+            root=meta_import.prefix,
+            is_custom=True,
+            vcs=the_vcs,
+        )
 
     @staticmethod
     def repo_root_for_import_path(import_path: str) -> vcs.Repository:
@@ -314,9 +364,13 @@ class GoResolver(DependencyResolver):
             version=GoVersion(version_string),  # type: ignore
             source=dependency.source,
             dependencies=[
-                Dependency(package=package, semantic_version=GoSpec(f"={version}"), source=dependency.source)
+                Dependency(
+                    package=package,
+                    semantic_version=GoSpec(f"={version}"),
+                    source=dependency.source,
+                )
                 for package, version in module.dependencies
-            ]
+            ],
         )
 
     @classmethod
@@ -351,5 +405,5 @@ class GoResolver(DependencyResolver):
             dependencies=[
                 Dependency(package=package, semantic_version=GoSpec(f"={version}"), source=self)
                 for package, version in module.dependencies
-            ]
+            ],
         )

--- a/it_depends/graphs.py
+++ b/it_depends/graphs.py
@@ -1,4 +1,15 @@
-from typing import Dict, Generic, Iterable, Iterator, Optional, Set, Tuple, Type, TypeVar, Union
+from typing import (
+    Dict,
+    Generic,
+    Iterable,
+    Iterator,
+    Optional,
+    Set,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+)
 
 import networkx as nx
 
@@ -32,15 +43,18 @@ class RootedDiGraph(nx.DiGraph, Generic[T, R]):
             path_lengths = [self.shortest_path_length(root, node) for root in self.roots]
             return min(length for length in path_lengths if length >= 0)
         elif self._shortest_path_from_root is None:
-            self._shortest_path_from_root = \
-                nx.single_source_shortest_path_length(self, next(iter(self.roots)))  # type: ignore
+            self._shortest_path_from_root = nx.single_source_shortest_path_length(
+                self, next(iter(self.roots))
+            )  # type: ignore
         return self._shortest_path_from_root[node]
 
     def shortest_path_length(self, from_node: Union[T, R], to_node: T) -> int:
         if self._all_pairs_shortest_paths is None:
             self._all_pairs_shortest_paths = dict(nx.all_pairs_shortest_path_length(self))  # type: ignore
-        if from_node not in self._all_pairs_shortest_paths \
-                or to_node not in self._all_pairs_shortest_paths[from_node]:  # type: ignore
+        if (
+            from_node not in self._all_pairs_shortest_paths
+            or to_node not in self._all_pairs_shortest_paths[from_node]
+        ):  # type: ignore
             return -1
         return self._all_pairs_shortest_paths[from_node][to_node]  # type: ignore
 
@@ -68,7 +82,9 @@ class RootedDiGraph(nx.DiGraph, Generic[T, R]):
         self._handle_new_node(v_of_edge)
         return super().add_edge(u_of_edge, v_of_edge, **attr)
 
-    def add_edges_from(self, ebunch_to_add: Iterable[Union[Tuple[T, T], Tuple[T, T, Dict]]], **attr):
+    def add_edges_from(
+        self, ebunch_to_add: Iterable[Union[Tuple[T, T], Tuple[T, T, Dict]]], **attr
+    ):
         edges = []
         for u, v, *r in ebunch_to_add:
             self._handle_new_node(u)
@@ -102,7 +118,9 @@ class RootedDiGraph(nx.DiGraph, Generic[T, R]):
         return compare_rooted_graphs(self, graph, normalize)
 
 
-def compare_rooted_graphs(graph1: RootedDiGraph[T, R], graph2: RootedDiGraph[T, R], normalize: bool = False) -> float:
+def compare_rooted_graphs(
+    graph1: RootedDiGraph[T, R], graph2: RootedDiGraph[T, R], normalize: bool = False
+) -> float:
     """Calculates the edit distance between two rooted graphs.
 
     If normalize == False (the default), a value of zero means the graphs are identical, with increasing values
@@ -132,9 +150,9 @@ def compare_rooted_graphs(graph1: RootedDiGraph[T, R], graph2: RootedDiGraph[T, 
     if normalize:
         if distance > 0.0:
             # the graphs are not identical
-            max_distance = \
-                sum(max(graph1.shortest_path_from_root(node), 1) for node in graph1) + \
-                sum(max(graph2.shortest_path_from_root(node), 1) for node in graph2)
+            max_distance = sum(
+                max(graph1.shortest_path_from_root(node), 1) for node in graph1
+            ) + sum(max(graph2.shortest_path_from_root(node), 1) for node in graph2)
             distance /= max_distance
         distance = 1.0 - distance
     return distance

--- a/it_depends/html.py
+++ b/it_depends/html.py
@@ -84,9 +84,9 @@ drawGraph();
 
 
 def graph_to_html(
-        graph: Union[DependencyGraph, PackageCache],
-        collapse_versions: bool = True,
-        title: Optional[str] = None
+    graph: Union[DependencyGraph, PackageCache],
+    collapse_versions: bool = True,
+    title: Optional[str] = None,
 ) -> str:
     if not isinstance(graph, DependencyGraph):
         graph = graph.to_graph()
@@ -113,11 +113,13 @@ def graph_to_html(
     for package, node_id in node_ids.items():
         nodes.append({"id": node_id, "label": package.full_name})
         if package in roots:
-            nodes[-1].update({
-                "shape": "square",
-                "color": "red",
-                "borderWidth": 4,
-            })
+            nodes[-1].update(
+                {
+                    "shape": "square",
+                    "color": "red",
+                    "borderWidth": 4,
+                }
+            )
         if package.vulnerabilities:
             nodes[-1].update({"color": "red"})
         if graph.source_packages:
@@ -129,11 +131,7 @@ def graph_to_html(
                 dep_name = f"{dep.source}:{dep.package}"
             else:
                 dep_name = str(dep)
-            edges.append({
-                "from": node_ids[pkg1],
-                "to": node_ids[pkg2],
-                "shape": "dot"
-            })
+            edges.append({"from": node_ids[pkg1], "to": node_ids[pkg2], "shape": "dot"})
             if dep_name != pkg2.full_name:
                 edges[-1]["label"] = dep_name
 
@@ -144,8 +142,9 @@ def graph_to_html(
         else:
             title = f"Dependency Graph for {source_packages}"
 
-    return TEMPLATE\
-        .replace("$NODES", repr(nodes))\
-        .replace("$EDGES", repr(edges))\
-        .replace("$TITLE", title)\
+    return (
+        TEMPLATE.replace("$NODES", repr(nodes))
+        .replace("$EDGES", repr(edges))
+        .replace("$TITLE", title)
         .replace("$LAYOUT", layout)
+    )

--- a/it_depends/it_depends.py
+++ b/it_depends/it_depends.py
@@ -4,5 +4,6 @@ import pkg_resources
 
 APP_DIRS = AppDirs("it-depends", "Trail of Bits")
 
+
 def version() -> str:
     return pkg_resources.require("it-depends")[0].version

--- a/it_depends/pip.py
+++ b/it_depends/pip.py
@@ -9,8 +9,16 @@ from johnnydep import JohnnyDist
 from johnnydep.logs import configure_logging
 
 from .dependencies import (
-    Dependency, DependencyResolver, DockerSetup, Package, PackageCache, SemanticVersion,
-    SimpleSpec, SourcePackage, SourceRepository, Version
+    Dependency,
+    DependencyResolver,
+    DockerSetup,
+    Package,
+    PackageCache,
+    SemanticVersion,
+    SimpleSpec,
+    SourcePackage,
+    SourceRepository,
+    Version,
 )
 
 
@@ -23,10 +31,14 @@ class PipResolver(DependencyResolver):
     description = "classifies the dependencies of Python packages using pip"
 
     def can_resolve_from_source(self, repo: SourceRepository) -> bool:
-        return self.is_available and (repo.path / "setup.py").exists() or (repo.path / "requirements.txt").exists()
+        return (
+            self.is_available
+            and (repo.path / "setup.py").exists()
+            or (repo.path / "requirements.txt").exists()
+        )
 
     def resolve_from_source(
-            self, repo: SourceRepository, cache: Optional[PackageCache] = None
+        self, repo: SourceRepository, cache: Optional[PackageCache] = None
     ) -> Optional[SourcePackage]:
         if not self.can_resolve_from_source(repo):
             return None
@@ -41,7 +53,7 @@ class PipResolver(DependencyResolver):
             load_package_script="""#!/usr/bin/env bash
     python3 -c "import $1"
     """,
-            baseline_script="#!/usr/bin/env python3 -c \"\"\n"
+            baseline_script='#!/usr/bin/env python3 -c ""\n',
         )
 
     @staticmethod
@@ -72,21 +84,28 @@ class PipResolver(DependencyResolver):
         return Dependency(package=name, semantic_version=version, source=PipResolver())
 
     @staticmethod
-    def get_dependencies(dist_or_requirements_txt_path: Union[JohnnyDist, Path, str]) -> Iterable[Dependency]:
+    def get_dependencies(
+        dist_or_requirements_txt_path: Union[JohnnyDist, Path, str]
+    ) -> Iterable[Dependency]:
         if isinstance(dist_or_requirements_txt_path, JohnnyDist):
             return (
                 Dependency(
-                    package=child.name, semantic_version=PipResolver._get_specifier(child), source=PipResolver()
+                    package=child.name,
+                    semantic_version=PipResolver._get_specifier(child),
+                    source=PipResolver(),
                 )
                 for child in dist_or_requirements_txt_path.children
             )
         elif isinstance(dist_or_requirements_txt_path, str):
             dist_or_requirements_txt_path = Path(dist_or_requirements_txt_path)
         with open(dist_or_requirements_txt_path / "requirements.txt", "r") as f:
-            return filter(lambda d: d is not None, (
-                PipResolver.parse_requirements_txt_line(line)  # type: ignore
-                for line in f.readlines()
-            ))
+            return filter(
+                lambda d: d is not None,
+                (
+                    PipResolver.parse_requirements_txt_line(line)  # type: ignore
+                    for line in f.readlines()
+                ),
+            )
 
     @staticmethod
     def get_version(version_str: str, none_default: Optional[Version] = None) -> Optional[Version]:
@@ -105,7 +124,7 @@ class PipResolver(DependencyResolver):
                             major=int(components[0]),
                             minor=int(components[1]),
                             patch=int(components[2]),
-                            prerelease=components[3]
+                            prerelease=components[3],
                         )
                     except ValueError:
                         pass
@@ -113,7 +132,10 @@ class PipResolver(DependencyResolver):
             return None
 
     def resolve_dist(
-            self, dist: JohnnyDist, recurse: bool = True, version: SemanticVersion = SimpleSpec("*")
+        self,
+        dist: JohnnyDist,
+        recurse: bool = True,
+        version: SemanticVersion = SimpleSpec("*"),
     ) -> Iterable[Package]:
         queue = [(dist, version)]
         packages: List[Package] = []
@@ -124,19 +146,19 @@ class PipResolver(DependencyResolver):
             else:
                 none_default = None
             for version in sem_version.filter(
-                    filter(
-                        lambda v: v is not None,
-                        (
-                                PipResolver.get_version(v_str, none_default=none_default)
-                                for v_str in dist.versions_available
-                        )
-                    )
+                filter(
+                    lambda v: v is not None,
+                    (
+                        PipResolver.get_version(v_str, none_default=none_default)
+                        for v_str in dist.versions_available
+                    ),
+                )
             ):
                 package = Package(
                     name=dist.name,
                     version=version,
                     dependencies=self.get_dependencies(dist),
-                    source=self
+                    source=self,
                 )
                 packages.append(package)
                 if not recurse:
@@ -145,12 +167,15 @@ class PipResolver(DependencyResolver):
         return packages
 
     def resolve(self, dependency: Dependency) -> Iterator[Package]:
-        print (dependency)
+        print(dependency)
         try:
-            return iter(self.resolve_dist(
-                JohnnyDist(f"{dependency.package}"), version=dependency.semantic_version,
-                recurse=False
-            ))
+            return iter(
+                self.resolve_dist(
+                    JohnnyDist(f"{dependency.package}"),
+                    version=dependency.semantic_version,
+                    recurse=False,
+                )
+            )
         except ValueError as e:
             log.warning(str(e))
             return iter(())
@@ -162,26 +187,42 @@ class PipSourcePackage(SourcePackage):
         version_str = dist.specifier
         if version_str.startswith("=="):
             version_str = version_str[2:]
-        return PipSourcePackage(name=dist.name,
-                                version=PipResolver.get_version(version_str),
-                                dependencies=PipResolver.get_dependencies(dist),
-                                source_repo=SourceRepository(source_path),
-                                source="pip")
+        return PipSourcePackage(
+            name=dist.name,
+            version=PipResolver.get_version(version_str),
+            dependencies=PipResolver.get_dependencies(dist),
+            source_repo=SourceRepository(source_path),
+            source="pip",
+        )
 
     @staticmethod
     def from_repo(repo: SourceRepository) -> "PipSourcePackage":
         if (repo.path / "setup.py").exists():
             with TemporaryDirectory() as tmp_dir:
-                subprocess.check_call([
-                    sys.executable, "-m", "pip", "wheel", "--no-deps", "-w", tmp_dir, str(repo.path.absolute())
-                ], stdout=sys.stderr)
+                subprocess.check_call(
+                    [
+                        sys.executable,
+                        "-m",
+                        "pip",
+                        "wheel",
+                        "--no-deps",
+                        "-w",
+                        tmp_dir,
+                        str(repo.path.absolute()),
+                    ],
+                    stdout=sys.stderr,
+                )
                 wheel = None
                 for whl in Path(tmp_dir).glob("*.whl"):
                     if wheel is not None:
-                        raise ValueError(f"`pip wheel --no-deps {repo.path!s}` produced mutliple wheel files!")
+                        raise ValueError(
+                            f"`pip wheel --no-deps {repo.path!s}` produced mutliple wheel files!"
+                        )
                     wheel = whl
                 if wheel is None:
-                    raise ValueError(f"`pip wheel --no-deps {repo.path!s}` did not produce a wheel file!")
+                    raise ValueError(
+                        f"`pip wheel --no-deps {repo.path!s}` did not produce a wheel file!"
+                    )
                 dist = JohnnyDist(str(wheel))
                 # force JohnnyDist to read the dependencies before deleting the wheel:
                 _ = dist.children
@@ -196,7 +237,12 @@ class PipSourcePackage(SourcePackage):
             else:
                 version = PipResolver.get_version("0.0.0")
                 log.info(f"Could not detect {repo.path} version. Using: {version}")
-            return PipSourcePackage(name=name, version=version, dependencies=PipResolver.get_dependencies(repo.path),
-                                    source_repo=repo, source="pip")
+            return PipSourcePackage(
+                name=name,
+                version=version,
+                dependencies=PipResolver.get_dependencies(repo.path),
+                source_repo=repo,
+                source="pip",
+            )
         else:
             raise ValueError(f"{repo.path} neither has a setup.py nor a requirements.txt")

--- a/it_depends/ubuntu/docker.py
+++ b/it_depends/ubuntu/docker.py
@@ -13,7 +13,9 @@ _container: Optional[DockerContainer] = None
 _UBUNTU_LOCK: Lock = Lock()
 
 _UBUNTU_NAME_MATCH: Pattern[str] = re.compile(r"^\s*name\s*=\s*\"ubuntu\"\s*$", flags=re.IGNORECASE)
-_VERSION_ID_MATCH: Pattern[str] = re.compile(r"^\s*version_id\s*=\s*\"([^\"]+)\"\s*$", flags=re.IGNORECASE)
+_VERSION_ID_MATCH: Pattern[str] = re.compile(
+    r"^\s*version_id\s*=\s*\"([^\"]+)\"\s*$", flags=re.IGNORECASE
+)
 
 logger = logging.getLogger(__name__)
 
@@ -56,14 +58,22 @@ def run_command(*args: str) -> bytes:
     with _UBUNTU_LOCK:
         global _container
         if _container is None:
-            with InMemoryDockerfile("""FROM ubuntu:20.04
+            with InMemoryDockerfile(
+                """FROM ubuntu:20.04
 
 RUN apt-get update && apt-get install -y apt-file && apt-file update
-""") as dockerfile:
+"""
+            ) as dockerfile:
                 _container = DockerContainer("trailofbits/it-depends-apt", dockerfile=dockerfile)
                 _container.rebuild()
     logger.debug(f"running {' '.join(args)} in Docker")
-    p = _container.run(*args, interactive=False, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, rebuild=False)
+    p = _container.run(
+        *args,
+        interactive=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        rebuild=False,
+    )
     if p.returncode != 0:
         raise subprocess.CalledProcessError(p.returncode, cmd=f"{' '.join(args)}")
     return p.stdout

--- a/it_depends/ubuntu/resolver.py
+++ b/it_depends/ubuntu/resolver.py
@@ -8,8 +8,18 @@ from typing import Iterable, Iterator, Optional
 from .apt import file_to_packages
 from .docker import is_running_ubuntu, run_command
 from ..dependencies import (
-    Dependency, DependencyResolver, Dict, List, Package, PackageCache, ResolverAvailability, SimpleSpec, SourcePackage,
-    SourceRepository, Tuple, Version
+    Dependency,
+    DependencyResolver,
+    Dict,
+    List,
+    Package,
+    PackageCache,
+    ResolverAvailability,
+    SimpleSpec,
+    SourcePackage,
+    SourceRepository,
+    Tuple,
+    Version,
 )
 from ..native import get_native_dependencies
 
@@ -48,7 +58,7 @@ class UbuntuResolver(DependencyResolver):
         packages: Dict[Tuple[str, Version], List[List[Dependency]]] = {}
         for line in contents.split("\n"):
             if line.startswith("Version: "):
-                matched = UbuntuResolver._ubuntu_version.match(line[len("Version: "):])
+                matched = UbuntuResolver._ubuntu_version.match(line[len("Version: ") :])
                 if matched:
                     # FIXME: Ubuntu versions can include "~", which the semantic_version library does not like
                     #        So hack a fix by simply dropping everything after the tilde:
@@ -65,9 +75,11 @@ class UbuntuResolver(DependencyResolver):
                         # Fixme: For now, treat each ORed dependency as a separate ANDed dependency
                         matched = UbuntuResolver._pattern.match(or_segment)
                         if not matched:
-                            raise ValueError(f"Invalid dependency line in apt output for {package_name}: {line!r}")
-                        dep_package = matched.group('package')
-                        dep_version = matched.group('version')
+                            raise ValueError(
+                                f"Invalid dependency line in apt output for {package_name}: {line!r}"
+                            )
+                        dep_package = matched.group("package")
+                        dep_version = matched.group("version")
                         try:
                             # remove trailing ubuntu versions like "-10ubuntu4":
                             dep_version = dep_version.split("-", maxsplit=1)[0]
@@ -78,11 +90,12 @@ class UbuntuResolver(DependencyResolver):
 
                         deps.append((dep_package, dep_version))
 
-                packages[(package_name, version)].append([
+                packages[(package_name, version)].append(
+                    [
                         Dependency(
                             package=pkg,
                             semantic_version=SimpleSpec(ver),
-                            source=UbuntuResolver()
+                            source=UbuntuResolver(),
                         )
                         for pkg, ver in deps
                     ]
@@ -98,14 +111,16 @@ class UbuntuResolver(DependencyResolver):
                 name=pkg_name,
                 version=version,
                 source=UbuntuResolver(),
-                dependencies=set().union(*duplicates)  # type: ignore
+                dependencies=set().union(*duplicates),  # type: ignore
             )
             for (pkg_name, version), duplicates in packages.items()
         ]
 
     def resolve(self, dependency: Dependency) -> Iterator[Package]:
         if dependency.source != "ubuntu":
-            raise ValueError(f"{self} can not resolve dependencies from other sources ({dependency})")
+            raise ValueError(
+                f"{self} can not resolve dependencies from other sources ({dependency})"
+            )
 
         if dependency.package.startswith("/"):
             # this is a file path, likely produced from native.py
@@ -118,7 +133,7 @@ class UbuntuResolver(DependencyResolver):
                         name=dependency.package,
                         source=dependency.source,
                         version=Version.coerce("0"),
-                        dependencies=deps
+                        dependencies=deps,
                     )
             except (ValueError, subprocess.CalledProcessError):
                 pass
@@ -133,15 +148,17 @@ class UbuntuResolver(DependencyResolver):
 
     def is_available(self) -> ResolverAvailability:
         if shutil.which("docker") is None:
-            return ResolverAvailability(False,
-                                        "`Ubuntu` classifier needs to have Docker installed. Try apt install docker.io.")
+            return ResolverAvailability(
+                False,
+                "`Ubuntu` classifier needs to have Docker installed. Try apt install docker.io.",
+            )
         return ResolverAvailability(True)
 
     def can_resolve_from_source(self, repo: SourceRepository) -> bool:
         return False
 
     def resolve_from_source(
-            self, repo: SourceRepository, cache: Optional[PackageCache] = None
+        self, repo: SourceRepository, cache: Optional[PackageCache] = None
     ) -> Optional[SourcePackage]:
         return None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+[tool.isort]
+line_length = 100
+multi_line_output = 3
+known_first_party = "it_depends"
+include_trailing_comma = true
+
+[tool.black]
+line-length = 100


### PR DESCRIPTION
This tweaks the Podman socket discovery to include rooted Podman socket support, and to fall back on a reasonable path for rootless Podman if `XDG_RUNTIME_DIR` is not set.