### PR TITLE
WIP: Support Aliased Dependencies in NPM

### DIFF
--- a/it_depends/dependencies.py
+++ b/it_depends/dependencies.py
@@ -138,6 +138,17 @@ class Dependency:
         )
 
 
+class AliasedDependency(Dependency):
+    def __init__(self,
+                 package: str,
+                 alias_name: str,
+                 source: Union[str, "DependencyResolver"],
+                 semantic_version: SemanticVersion = SimpleSpec("*"),
+                 ):
+        self.alias_name = alias_name
+        super().__init__(package, source, semantic_version)
+
+
 class Package:
     def __init__(
         self,


### PR DESCRIPTION
At the moment, the support for NPM dependencies fails at aliased dependencies.

Example for angular [package.json](https://github.com/angular/angular/blob/d9a1a7dd07497768b1c70fe698b1547bd1f8488e/package.json#L89)

```json
    "@types/node": "^16.11.7",
    "@types/selenium-webdriver": "3.0.7",
    "@types/selenium-webdriver4": "npm:@types/selenium-webdriver@4.1.21",
    "@types/semver": "^7.3.4",
    "@types/shelljs": "^0.8.6",
```


This PR tries to handle this case by :

- Adding an AliasedDependency class that inherits from Dependencies.
- Installing dependencies from the real source instead of the alias name

