### PR TITLE
Adds a generic dependency resolver

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v2

--- a/it_depends/cli.py
+++ b/it_depends/cli.py
@@ -14,7 +14,7 @@ from .dependencies import Dependency, resolvers, resolve, SourceRepository
 from .it_depends import version as it_depends_version
 from .html import graph_to_html
 from .resolver import resolve_sbom
-from .sbom import cyclonedx_to_json, SBOM
+from .sbom import cyclonedx_to_json
 
 
 @contextmanager
@@ -107,19 +107,25 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         "-f",
         choices=("json", "dot", "html", "cyclonedx"),
         default="json",
-        help="how the output should be formatted (default is JSON)",
+        help="how the output should be formatted (default is JSON); note that `cyclonedx` will output a single "
+             "satisfying dependency resolution rather than the universe of all possible resolutions "
+             "(see `--newest-resolution`)",
     )
+    parser.add_argument("--latest-resolution", "-lr", action="store_true",
+                        help="by default, the `cyclonedx` output format emits a single satisfying dependency "
+                             "resolution containing the oldest versions of all of the packages possible; this option "
+                             "instead returns the latest latest possible resolution")
     parser.add_argument(
         "--output-file",
         "-o",
         type=str,
         default=None,
-        help="path to the output file; default is to " "write output to STDOUT",
+        help="path to the output file; default is to write output to STDOUT",
     )
     parser.add_argument(
         "--force",
         action="store_true",
-        help="force overwriting the output file even if it already " "exists",
+        help="force overwriting the output file even if it already exists",
     )
     parser.add_argument(
         "--all-versions",
@@ -292,7 +298,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
                 elif args.output_format == "cyclonedx":
                     sbom = None
                     for p in package_list:
-                        for bom in resolve_sbom(p, package_list, order_ascending=True):
+                        for bom in resolve_sbom(p, package_list, order_ascending=not args.latest_resolution):
                             if sbom is None:
                                 sbom = bom
                             else:

--- a/it_depends/cli.py
+++ b/it_depends/cli.py
@@ -297,7 +297,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
                     output_file.write(json.dumps(package_list.to_obj(), indent=4))
                 elif args.output_format == "cyclonedx":
                     sbom = None
-                    for p in package_list:
+                    for p in package_list.source_packages:
                         for bom in resolve_sbom(p, package_list, order_ascending=not args.latest_resolution):
                             if sbom is None:
                                 sbom = bom

--- a/it_depends/dependencies.py
+++ b/it_depends/dependencies.py
@@ -130,7 +130,7 @@ class Dependency:
     def __hash__(self):
         return hash((self.source, self.package, self.semantic_version))
 
-    def match(self, package: "Package"):
+    def match(self, package: "Package") -> bool:
         """True if package is a solution for this dependency"""
         return (
             package.source == self.source
@@ -264,6 +264,10 @@ class Package:
 
     def dumps(self) -> str:
         return json.dumps(self.to_obj())
+
+    def same_package(self, other: "Package") -> bool:
+        """Checks if two packages are the same, but potentially different versions"""
+        return self.name == other.name and self.source == other.source
 
     def __eq__(self, other):
         if isinstance(other, Package):

--- a/it_depends/resolver.py
+++ b/it_depends/resolver.py
@@ -171,7 +171,7 @@ def resolve_sbom(root_package: Package, packages: PackageCache, order_ascending:
         yield SBOM((), (root_package,))
         return
 
-    logger.info(f"Resolving the {['oldest', 'newest'][order_ascending]} possible SBOM for {root_package.name}")
+    logger.info(f"Resolving the {['newest', 'oldest'][order_ascending]} possible SBOM for {root_package.name}")
 
     stack: List[PartialResolution] = [
         PartialResolution(packages=(root_package,))

--- a/it_depends/resolver.py
+++ b/it_depends/resolver.py
@@ -1,0 +1,207 @@
+from collections import defaultdict
+from typing import Dict, FrozenSet, Iterable, Iterator, List, Optional, Set, Tuple
+
+from semantic_version.base import AllOf, BaseSpec
+
+from .dependencies import Dependency, Package, PackageCache
+from .sbom import SBOM
+
+
+class CompoundSpec(BaseSpec):
+    def __init__(self, *to_combine: BaseSpec):
+        super(CompoundSpec, self).__init__(",".join(s.expression for s in to_combine))
+        self.clause = AllOf(*(s.clause for s in to_combine))
+
+    @classmethod
+    def _parse_to_clause(cls, expression):
+        """Converts an expression to a clause."""
+        # Placeholder, we actually set self.clause in self.__init__
+        return None
+
+
+class PackageSet:
+    def __init__(self):
+        self._packages: Dict[Tuple[str, str], Package] = {}
+        self._unsatisfied: Dict[Tuple[str, str], Dict[Dependency, Set[Package]]] = \
+            defaultdict(lambda: defaultdict(set))
+        self.is_valid: bool = True
+        self.is_complete: bool = True
+
+    def __eq__(self, other):
+        return isinstance(other, PackageSet) and self._packages.values() == other._packages.values()
+
+    def __hash__(self):
+        return hash(frozenset(self._packages.values()))
+
+    def __len__(self):
+        return len(self._packages)
+
+    def __iter__(self) -> Iterator[Package]:
+        yield from self._packages.values()
+
+    def __contains__(self, package: Package) -> bool:
+        pkg_spec = (package.name, package.source)
+        return pkg_spec in self._packages and self._packages[pkg_spec] == package
+
+    def unsatisfied_dependencies(self) -> Iterator[Tuple[Dependency, FrozenSet[Package]]]:
+        for (pkg_name, pkg_source), deps in sorted(
+                # try the dependencies with the most options first
+                self._unsatisfied.items(),
+                key=lambda x: (len(x[1]), x[0]),
+                reverse=True
+        ):
+            if len(deps) == 0:
+                continue
+            elif len(deps) == 1:
+                dep, packages = next(iter(deps.items()))
+            else:
+                # there are multiple requirements for the same dependency
+                spec = CompoundSpec(*(d.semantic_version for d in deps.keys()))
+                dep = Dependency(pkg_name, pkg_source, spec)
+                packages = {
+                    p
+                    for packages in deps.values()
+                    for p in packages
+                }
+
+            yield dep, frozenset(packages)
+
+    def copy(self) -> "PackageSet":
+        ret = PackageSet()
+        ret._packages = self._packages.copy()
+        ret._unsatisfied = defaultdict(lambda: defaultdict(set))
+        for dep_spec, deps in self._unsatisfied.items():
+            ret._unsatisfied[dep_spec] = defaultdict(set)
+            for dep, packages in deps.items():
+                ret._unsatisfied[dep_spec][dep] = set(packages)
+                assert all(p in ret for p in packages)
+        ret.is_valid = self.is_valid
+        ret.is_complete = self.is_complete
+        return ret
+
+    def add(self, package: Package):
+        pkg_spec = (package.name, package.source)
+        if pkg_spec in self._packages and self._packages[pkg_spec].version != package.version:
+            self.is_valid = False
+        if not self.is_valid:
+            return
+        self._packages[pkg_spec] = package
+        if pkg_spec in self._unsatisfied:
+            # there are some existing packages that have unsatisfied dependencies that could be
+            # satisfied by this new package
+            for dep in list(self._unsatisfied[pkg_spec].keys()):
+                if dep.match(package):
+                    del self._unsatisfied[pkg_spec][dep]
+                    if len(self._unsatisfied[pkg_spec]) == 0:
+                        del self._unsatisfied[pkg_spec]
+        # add any new unsatisfied dependencies for this package
+        for dep in package.dependencies:
+            dep_spec = (dep.package, dep.source)
+            if dep_spec not in self._packages:
+                self._unsatisfied[dep_spec][dep].add(package)
+            elif not dep.match(self._packages[dep_spec]):
+                self.is_valid = False
+                break
+
+        self.is_complete = self.is_valid and len(self._unsatisfied) == 0
+
+
+class PartialResolution:
+    def __init__(self, packages: Iterable[Package] = (), dependencies: Iterable[Package] = (),
+                 parent: Optional["PartialResolution"] = None):
+        self._packages: FrozenSet[Package] = frozenset(packages)
+        self._dependencies: FrozenSet[Package] = frozenset(dependencies)
+        self.parent: Optional[PartialResolution] = parent
+        if self.parent is not None:
+            self.packages: PackageSet = self.parent.packages.copy()
+        else:
+            self.packages = PackageSet()
+        for package in self._packages:
+            self.packages.add(package)
+            if not self.is_valid:
+                break
+        if self.is_valid:
+            for dep in self._dependencies:
+                self.packages.add(dep)
+                if not self.is_valid:
+                    break
+
+    @property
+    def is_valid(self) -> bool:
+        return self.packages.is_valid
+
+    @property
+    def is_complete(self) -> bool:
+        return self.packages.is_complete
+
+    def __contains__(self, package: Package) -> bool:
+        return package in self.packages
+
+    def add(self, packages: Iterable[Package], depends_on: Package) -> "PartialResolution":
+        return PartialResolution(packages, (depends_on,), parent=self)
+
+    def packages(self) -> Iterator[Package]:
+        yield from self.packages
+
+    __iter__ = packages
+
+    def dependencies(self) -> Iterator[Tuple[Package, Package]]:
+        pr: Optional[PartialResolution] = self
+        while pr is not None:
+            for depends_on in sorted(pr._dependencies):
+                for package in pr._packages:
+                    yield package, depends_on
+            pr = pr.parent
+
+    def __len__(self) -> int:
+        return len(self.packages)
+
+    def __eq__(self, other):
+        return isinstance(other, PartialResolution) and self.packages == other.packages
+
+    def __hash__(self):
+        return hash(self.packages)
+
+
+def resolve_sbom(root_package: Package, packages: PackageCache, order_ascending: bool = True) -> Iterator[SBOM]:
+    if not root_package.dependencies:
+        yield SBOM((), (root_package,))
+        return
+
+    stack: List[PartialResolution] = [
+        PartialResolution(packages=(root_package,))
+    ]
+
+    history: Set[PartialResolution] = {
+        pr for pr in stack
+        if pr.is_valid
+    }
+
+    while stack:
+        pr = stack.pop()
+        if pr.is_complete:
+            yield SBOM(pr.dependencies(), root_packages=(root_package,))
+            continue
+        elif not pr.is_valid:
+            continue
+
+        sorted_deps = sorted(
+            pr.packages.unsatisfied_dependencies(),
+            key=lambda d: (len(d[1]), d[0].package, d[0].source),
+            reverse=True
+        )
+
+        # traverse the dependencies in order of decreasing constraints
+
+        for dep, required_by in sorted_deps:
+            if not PartialResolution(packages=required_by, parent=pr).is_valid:
+                continue
+            for match in sorted(
+                    packages.match(dep),
+                    key=lambda p: p.version,
+                    reverse=order_ascending
+            ):
+                next_pr = pr.add(required_by, match)
+                if next_pr.is_valid and next_pr not in history:
+                    history.add(next_pr)
+                    stack.append(next_pr)

--- a/it_depends/sbom.py
+++ b/it_depends/sbom.py
@@ -47,6 +47,7 @@ class SBOM:
             root_component = Component(
                 name=root_package.name,
                 type=ComponentType.APPLICATION,
+                version=str(root_package.version),
                 bom_ref=root_package.full_name,
             )
             bom.components.add(root_component)

--- a/it_depends/sbom.py
+++ b/it_depends/sbom.py
@@ -1,4 +1,4 @@
-from typing import Dict, Iterable, List, Optional, Tuple
+from typing import Dict, FrozenSet, Iterable, List, Optional, Tuple, Type, TypeVar
 
 from cyclonedx.builder.this import this_component as cdx_lib_component
 from cyclonedx.model import XsUri
@@ -8,21 +8,50 @@ from cyclonedx.model.contact import OrganizationalEntity
 from cyclonedx.output.json import JsonV1Dot5
 
 from . import version
-from .dependencies import PackageCache, Package
+from .dependencies import Package
 
-__all__ = "package_to_cyclonedx", "cyclonedx_to_json"
+__all__ = "cyclonedx_to_json", "SBOM"
 
 
-def package_to_cyclonedx(
-        package: Package, packages: PackageCache, bom: Optional[Bom] = None, only_latest: bool = False
-) -> Bom:
-    root_component = Component(
-        name=package.name,
-        type=ComponentType.APPLICATION,
-        bom_ref=package.full_name,
-    )
-    if bom is None:
+S = TypeVar("S", bound="SBOM")
+
+
+class SBOM:
+    def __init__(self, dependencies: Iterable[Tuple[Package, Package]] = (), root_packages: Iterable[Package] = ()):
+        self.dependencies: FrozenSet[Tuple[Package, Package]] = frozenset(dependencies)
+        self.root_packages: FrozenSet[Package] = frozenset(root_packages)
+
+    @property
+    def packages(self) -> FrozenSet[Package]:
+        return self.root_packages | {
+            p
+            for deps in self.dependencies
+            for p in deps
+        }
+
+    def __str__(self):
+        return ", ".join(p.full_name for p in sorted(self.packages))
+
+    def to_cyclonedx(self) -> Bom:
         bom = Bom()
+
+        expanded: Dict[Package, Component] = {}
+
+        root_component: Optional[Component] = None
+
+        for root_package in sorted(
+                self.root_packages,
+                key=lambda package: package.full_name,
+                reverse=True
+        ):
+            root_component = Component(
+                name=root_package.name,
+                type=ComponentType.APPLICATION,
+                bom_ref=root_package.full_name,
+            )
+            bom.components.add(root_component)
+            expanded[root_package] = root_component
+
         bom.metadata.tools.components.add(cdx_lib_component())
         bom.metadata.tools.components.add(Component(
             name="it-depends",
@@ -34,48 +63,43 @@ def package_to_cyclonedx(
             version=version(),
         ))
 
-        bom.metadata.component = root_component
+        if root_component is not None:
+            bom.metadata.component = root_component
 
-    package_queue: List[Tuple[Optional[Component], Package]] = [(None, package)]
-
-    expanded: Dict[Package, Component] = {}
-
-    while package_queue:
-        parent_component, pkg = package_queue.pop()
-
-        if pkg in expanded:
-            if parent_component is not None:
-                bom.register_dependency(parent_component, [expanded[pkg]])
-            continue
-
-        component = Component(
-            name=pkg.name,
-            type=ComponentType.LIBRARY,
-            version=str(pkg.version),
-            bom_ref=f"{pkg.full_name}@{pkg.version!s}"
-        )
-
-        expanded[pkg] = component
-
-        bom.components.add(component)
-        if parent_component is not None:
-            bom.register_dependency(parent_component, [component])
-
-        for dep in pkg.dependencies:
-            if only_latest:
-                latest = packages.latest_match(dep)
-                if latest is None:
-                    continue
-                matches: Iterable[Package] = (latest,)
+        for pkg, depends_on in self.dependencies:
+            if pkg not in expanded:
+                component = Component(
+                    name=pkg.name,
+                    type=ComponentType.LIBRARY,
+                    version=str(pkg.version),
+                    bom_ref=f"{pkg.full_name}@{pkg.version!s}"
+                )
+                bom.components.add(component)
             else:
-                matches = packages.match(dep)
-            for resolved in matches:
-                if resolved in expanded:
-                    bom.register_dependency(component, [expanded[resolved]])
-                else:
-                    package_queue.append((component, resolved))
+                component = expanded[pkg]
+            if depends_on not in expanded:
+                d_component = Component(
+                    name=depends_on.name,
+                    type=ComponentType.LIBRARY,
+                    version=str(depends_on.version),
+                    bom_ref=f"{depends_on.full_name}@{depends_on.version!s}"
+                )
+                bom.components.add(d_component)
+            else:
+                d_component = expanded[depends_on]
+            bom.register_dependency(component, [d_component])
 
-    return bom
+        return bom
+
+    def __or__(self, other: "SBOM") -> "SBOM":
+        return SBOM(self.dependencies | other.dependencies, self.root_packages | other.root_packages)
+
+    def __hash__(self):
+        return hash((self.root_packages, self.dependencies))
+
+    def __eq__(self, other):
+        return isinstance(other, SBOM) and self.root_packages == other.root_packages \
+            and self.dependencies == other.dependencies
 
 
 def cyclonedx_to_json(bom: Bom, indent: int = 2) -> str:

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     license="LGPL-3.0-or-later",
     url="https://github.com/trailofbits/it-depends",
     author="Trail of Bits",
-    version="0.1.2",
+    version="0.1.3",
     packages=find_packages(exclude=["test"]),
     python_requires=">=3.7",
     install_requires=[

--- a/test/test_resolver.py
+++ b/test/test_resolver.py
@@ -1,0 +1,17 @@
+from unittest import TestCase
+
+from it_depends.resolver import resolve_sbom
+from it_depends.sbom import cyclonedx_to_json
+
+from .test_smoke import SmokeTest
+
+
+class TestResolver(TestCase):
+    def test_resolve(self):
+        test = SmokeTest("trailofbits", "it-depends", "3db3d191ce04fb8a19bcc5c000ce84dbb3243f31")
+        packages = test.run()
+        for package in packages.source_packages:
+            for sbom in resolve_sbom(package, packages, order_ascending=True):
+                # print(str(sbom))
+                print(cyclonedx_to_json(sbom.to_cyclonedx()))
+                break


### PR DESCRIPTION
By default now, for `cyclonedx` output format, we resolve the oldest set of dependencies that satisfy the requirements. This is in contrast to the existing (and preserved) behavior of the `json` output format, which emits the entire universe of possible resolutions. The `--latest-resolution` option returns the newest possible set of satisfying dependences rather than the oldest.