### PR TITLE
Migrate to Trusted Publishing

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -1,36 +1,59 @@
-# This workflows will upload a Python Package using Twine when a release is created
-# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
-
-name: Upload Python Package
-
 on:
   release:
-    types: [published]
+    types:
+      - published
 
-permissions:
-  contents: read
+name: release
+
+permissions: {}
+
 
 jobs:
-  deploy:
-
-    runs-on: ubuntu-22.04
-
+  build:
+    name: Build distributions
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         persist-credentials: false
+
     - name: Set up Python
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
-        python-version: '3.x'
+        python-version: "3.x"
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel twine
-    - name: Build and publish
-      env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        pip install setuptools wheel
+
+    - name: Build distributions
       run: |
         python setup.py sdist bdist_wheel
-        twine upload dist/*
+
+    - name: Upload distributions
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: distributions
+        path: dist/
+
+  publish:
+    name: Publish Python distributions to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/it-depends
+    needs: [build]
+    permissions:
+      # Used to sign the release's artifacts with sigstore-python.
+      # Used to publish to PyPI with Trusted Publishing.
+      id-token: write
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: distributions
+          path: dist/
+
+      - name: Publish distributions
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0


### PR DESCRIPTION
This PR adapts the PyPI publishing workflow to use Trusted Publishing. It's based on our [template](https://github.com/trailofbits/cookiecutter-python/blob/main/%7B%7Bcookiecutter.project_slug%7D%7D/.github/workflows/release.yml), but leaving the build invocation the same for now.

I've also created the corresponding trusted publisher on PyPI:
<img width="630" height="147" alt="image" src="https://github.com/user-attachments/assets/fc6cbbe1-6aa5-4d5d-93ab-a7414f163583" />
