### PR TITLE
Count only successful openat calls in native resolution

### DIFF
--- a/src/it_depends/native.py
+++ b/src/it_depends/native.py
@@ -71,6 +71,12 @@ STRACE_LIBRARY_REGEX = re.compile(
         (\.(.+?))?          # group 6: version suffix with dot (e.g. ".6"), group 7: digits only (e.g. "6")
     )
     \"                       # closing quote of the path argument
+    (?!.*=\s*-)              # reject failed calls: strace renders a failure as "= -1 ERRNO"
+                             # (e.g. the dynamic loader's "= -1 ENOENT" search-path probes),
+                             # whose negative return previously matched the old ".*" tail and
+                             # flooded native resolution with bogus library paths. A successful
+                             # open ("= 4") or an interrupted "<unfinished ...>" line has no
+                             # "= -" and is kept.
     .*                       # remainder of the line (flags, return value, etc.)
     """,
     re.VERBOSE,

--- a/test/test_native.py
+++ b/test/test_native.py
@@ -109,6 +109,19 @@ class TestStraceLibraryRegex(TestCase):
             line = f'openat(AT_FDCWD, "{path}", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)'
             assert STRACE_LIBRARY_REGEX.match(line) is None, path
 
+    def test_successful_hwcaps_path_still_matches(self) -> None:
+        """A library actually loaded from a hwcaps path must be kept, not dropped.
+
+        The filter keys off the return value, not the path shape: an optimized
+        library opened successfully (= 3) from a glibc-hwcaps directory is a real
+        dependency. This guards against a future over-broad fix that excludes all
+        hwcaps paths and would silently lose genuinely loaded libraries.
+        """
+        line = 'openat(AT_FDCWD, "/lib/glibc-hwcaps/x86-64-v3/libc.so.6", O_RDONLY|O_CLOEXEC) = 3'
+        m = STRACE_LIBRARY_REGEX.match(line)
+        assert m is not None
+        assert m.group(3) == "/lib/glibc-hwcaps/x86-64-v3/libc.so.6"
+
     def test_failed_open_with_pid_prefix_does_not_match(self) -> None:
         """Failed openat probes from strace -f child processes are also excluded."""
         line = '[pid  789] openat(AT_FDCWD, "/usr/lib/libfoo.so.1", O_RDONLY) = -1 ENOENT (No such file or directory)'

--- a/test/test_native.py
+++ b/test/test_native.py
@@ -68,6 +68,52 @@ class TestStraceLibraryRegex(TestCase):
         assert m is not None
         assert m.group(3) == "/etc/ld.so.cache"
 
+    def test_failed_open_does_not_match(self) -> None:
+        """Failed openat probes (ENOENT) must not be counted as loaded libraries."""
+        line = (
+            'openat(AT_FDCWD, "/lib/x86_64-linux-gnu/libc.so.6", O_RDONLY|O_CLOEXEC) '
+            "= -1 ENOENT (No such file or directory)"
+        )
+        assert STRACE_LIBRARY_REGEX.match(line) is None
+
+    def test_non_enoent_failure_does_not_match(self) -> None:
+        """Any negative return (not just ENOENT) is a failure and must be excluded."""
+        line = 'openat(AT_FDCWD, "/lib/libfoo.so.1", O_RDONLY) = -1 EACCES (Permission denied)'
+        assert STRACE_LIBRARY_REGEX.match(line) is None
+
+    def test_unfinished_open_still_matches(self) -> None:
+        """A successful open split by `strace -f` interleaving is kept.
+
+        The kernel can interrupt a syscall mid-line, emitting the path on a
+        "<unfinished ...>" line and the return value on a later "resumed" line.
+        The unfinished line carries the path and no failure marker, so it must
+        still match; otherwise a genuinely loaded library would be dropped
+        non-deterministically depending on scheduling.
+        """
+        line = '[pid  123] openat(AT_FDCWD, "/lib/x86_64-linux-gnu/libc.so.6", O_RDONLY|O_CLOEXEC <unfinished ...>'
+        m = STRACE_LIBRARY_REGEX.match(line)
+        assert m is not None
+        assert m.group(3) == "/lib/x86_64-linux-gnu/libc.so.6"
+
+    def test_hwcaps_probe_paths_do_not_match(self) -> None:
+        """The dynamic loader's hwcaps search-path probes fail with ENOENT and are excluded.
+
+        These bogus paths previously flooded native resolution with slow apt-file
+        Docker searches, timing out test_determinism_npm.
+        """
+        for path in (
+            "/lib/glibc-hwcaps/x86-64-v3/libproviders.so",
+            "/lib/tls/x86_64/x86_64/libproviders.so",
+            "/lib/x86_64-linux-gnu/glibc-hwcaps/x86-64-v2/libproviders.so",
+        ):
+            line = f'openat(AT_FDCWD, "{path}", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)'
+            assert STRACE_LIBRARY_REGEX.match(line) is None, path
+
+    def test_failed_open_with_pid_prefix_does_not_match(self) -> None:
+        """Failed openat probes from strace -f child processes are also excluded."""
+        line = '[pid  789] openat(AT_FDCWD, "/usr/lib/libfoo.so.1", O_RDONLY) = -1 ENOENT (No such file or directory)'
+        assert STRACE_LIBRARY_REGEX.match(line) is None
+
 
 class TestNative(TestCase):
     def test_native(self) -> None:


### PR DESCRIPTION
## Problem

The integration test `test/test_smoke.py::TestResolvers::test_determinism_npm` times out in CI (>600s, [example run](https://github.com/trailofbits/it-depends/actions/runs/27922517385/job/82618611879)).

The cause is in `native.py`. `get_native_dependencies` runs the package's load script under `strace -e open,openat -f` and extracts every `.so` path matched by `STRACE_LIBRARY_REGEX`. The regex ended with `.*`, ignoring the syscall return value, so it matched lines that failed with `= -1 ENOENT` just like successful loads.

This captured the dynamic loader's failed search-path probes — glibc hwcaps permutations such as `/lib/glibc-hwcaps/x86-64-v3/libproviders.so` and `/lib/tls/x86_64/x86_64/libproviders.so` — none of which exist. Each bogus path became an `ubuntu:<path>` dependency resolved via `apt-file -x search <path>`, a regex scan over the entire Contents index run as a separate `docker run` and serialized behind a global lock (`ubuntu/docker.py`). On `ubuntu:22.04` these probes number in the dozens; the failing run issued 56 such searches and the test exceeded the 600s `pytest-timeout`.

## Fix

Require a non-negative return value in the regex so only libraries that actually loaded are counted. Successful opens return a file descriptor (`= 4`); failed probes return `= -1 ENOENT` and are now excluded.

## Tests

Added regression cases to `TestStraceLibraryRegex` covering plain `ENOENT` failures, the hwcaps probe paths from the failing run, and a `[pid ...]` failure line. Existing match cases all use successful returns and are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)